### PR TITLE
Changing package.json to 1.4.2 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsenv-brunch",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Add support for processing .jsenv files to Brunch. Read environment values to compile to JS.",
   "author": "Ryan Sorensen (https://github.com/rcs)",
   "homepage": "https://github.com/rcs/jsenv-brunch",


### PR DESCRIPTION
The version that is uploaded to npm (which is 1.4.1) it's pretty different to the one that's found in the repo. The idea of this patch is to change the version in order to upload the new version of the plugin to npm.
