### PR TITLE
Be less opinionated about Coffeescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": "~0.6.10 || 0.8 || 0.9"
   },
   "dependencies": {
-    "coffee-script": "1.3.3"
+    "coffee-script": "*"
   },
   "devDependencies": {
     "mocha": "1.3.2",


### PR DESCRIPTION
We encountered a problem where our test harness (Mocha) would load dependencies in whatever order it wants (unlike Brunch). jsenv-brunch was loading first, hence an ancient version of Coffeescript got stuck in the node modules cache and ruined the rest of our day.

Maybe we can just be less opinionated about which Coffeescript version to depend on in jsenv-brunch?
