### PR TITLE
Coffeescript >=1.7.1 is a way better choice

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": "~0.6.10 || 0.8 || 0.9"
   },
   "dependencies": {
-    "coffee-script": "*"
+    "coffee-script": "~1.7.1"
   },
   "devDependencies": {
     "mocha": "1.3.2",


### PR DESCRIPTION
…since it doesn't monkeypatch the node `require()` system by default.

All we need for jsenv-brunch is the `compile()` method; we don't need to ruin other people's day by monkeypatching the node require system to use Coffeescript v?.?.? at runtime.
