### PR TITLE
Accept Node ~0.6.10, 0.8, and >=0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "node setup.js test"
   },
   "engines": {
-    "node": "~0.6.10 || 0.8 || 0.9"
+    "node": "~0.6.10 || 0.8 || >=0.9"
   },
   "dependencies": {
     "coffee-script": "*"


### PR DESCRIPTION
Unless there's a reason not to?
